### PR TITLE
action.py: set PIP_NO_CACHE_DIR during pip-audit

### DIFF
--- a/action.py
+++ b/action.py
@@ -89,6 +89,7 @@ status = subprocess.run(
     text=True,
     stdout=subprocess.PIPE,
     stderr=subprocess.STDOUT,
+    env={"PIP_NO_CACHE_DIR": "1"},
 )
 if status.returncode == 0:
     _log("🎉 pip-audit exited successfully")

--- a/action.py
+++ b/action.py
@@ -89,7 +89,7 @@ status = subprocess.run(
     text=True,
     stdout=subprocess.PIPE,
     stderr=subprocess.STDOUT,
-    env={"PIP_NO_CACHE_DIR": "1"},
+    env=os.environ | {"PIP_NO_CACHE_DIR": "1"},
 )
 if status.returncode == 0:
     _log("🎉 pip-audit exited successfully")


### PR DESCRIPTION
There's a bug in `pip-audit` that causes us to not respect `--cache-dir` when auditing a `pyproject.toml`-based project. I need to fix that, but this patches around it for the time being.

Signed-off-by: William Woodruff <william@trailofbits.com>